### PR TITLE
MoPub sample, fixed libGDX example

### DIFF
--- a/mopub/src/org/robovm/bindings/mopub/Sample.java
+++ b/mopub/src/org/robovm/bindings/mopub/Sample.java
@@ -88,9 +88,8 @@ public class Sample extends UIApplicationDelegate.Adapter {
 
 		// If you are already using a UIWindow, you can do the following (f.e. LibGDX):
 		// UIView interstitialView = new UIView(UIScreen.getMainScreen().getBounds());
-		// interstitialView.setUserInteractionEnabled(false);
 		// interstitialViewController.setView(interstitialView);
-		// application.getKeyWindow().addSubview(interstitialViewController.getView());
+		// gdxApplication.getUIViewController().getView().addSubview(interstitialViewController.getView()); // gdxApplication - your GDX IOSApplication
 	}
 
 	public static void main(String[] argv) {


### PR DESCRIPTION
setUserInteractionEnabled(false) deleted because ads must be clickable.

Btw, interstitial.loadAd() in didDisappear and didExpire - bad idea, bacause initiate loop loading, about 10 requests per second. Useless cpu and network loading.
