### PR TITLE
Fixed getPercentComplete

### DIFF
--- a/gamecenter/src/org/robovm/bindings/cocoatouch/gamekit/GKAchievement.java
+++ b/gamecenter/src/org/robovm/bindings/cocoatouch/gamekit/GKAchievement.java
@@ -1,4 +1,3 @@
-
 package org.robovm.bindings.cocoatouch.gamekit;
 
 import org.robovm.bindings.cocoatouch.blocks.VoidNSArrayNSErrorBlock;
@@ -98,9 +97,9 @@ public class GKAchievement extends NSObject {
 	 * @return */
 	public double getPercentComplete () {
 		if (customClass) {
-			return objc_getPercentCompleteSuper(getSuper(), identifier);
+			return objc_getPercentCompleteSuper(getSuper(), percentComplete);
 		} else {
-			return objc_getPercentComplete(this, identifier);
+			return objc_getPercentComplete(this, percentComplete);
 		}
 	}
 


### PR DESCRIPTION
The author accidentally copy pasted the 'identifier' selector and forgot to replace it with the 'getPercentComplete' selector. This caused a bug while obtining the percentage of an achievement.
