### PR TITLE
Fix for Game Center to open the correct views

### DIFF
--- a/gamecenter/src/org/robovm/bindings/cocoatouch/gamekit/GKGameCenterViewControllerState.java
+++ b/gamecenter/src/org/robovm/bindings/cocoatouch/gamekit/GKGameCenterViewControllerState.java
@@ -4,8 +4,8 @@ package org.robovm.bindings.cocoatouch.gamekit;
 import org.robovm.rt.bro.ValuedEnum;
 
 public enum GKGameCenterViewControllerState implements ValuedEnum {
-	GKGameCenterViewControllerStateDefault(0), GKGameCenterViewControllerStateLeaderboards(1), GKGameCenterViewControllerStateAchievements(
-		2), GKGameCenterViewControllerStateChallenges(3);
+	GKGameCenterViewControllerStateDefault(-1), GKGameCenterViewControllerStateLeaderboards(0), GKGameCenterViewControllerStateAchievements(
+		1), GKGameCenterViewControllerStateChallenges(2);
 
 	private final long n;
 


### PR DESCRIPTION
This fixes a GameCenterManager showAchievementsView() bug for iOS 6 that displays the Challenges view instead of Achievements.

See https://developer.apple.com/library/ios/documentation/GameKit/Reference/GKGameCenterViewController_Ref/Reference/Reference.html
