### PR TITLE
Prepare bindings to work with new RoboVM packaging mechanism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,15 @@ allprojects {
     launchIPadSimulator.dependsOn build
     launchIOSDevice.dependsOn build
     createIPA.dependsOn build
+
+    jar {
+      into('META-INF/robovm/ios') {
+        from(".") { include "robovm.xml" }        
+      }
+      into('META-INF/robovm/ios/libs') {
+        from 'libs'
+      }
+    }
 }
 
 task wrapper(type: Wrapper) {

--- a/google-play-game-services/src/org/robovm/bindings/gpgs/GPGError.java
+++ b/google-play-game-services/src/org/robovm/bindings/gpgs/GPGError.java
@@ -1,7 +1,9 @@
 
 package org.robovm.bindings.gpgs;
 
+import org.robovm.apple.foundation.NSDictionary;
 import org.robovm.apple.foundation.NSError;
+import org.robovm.apple.foundation.NSString;
 import org.robovm.objc.ObjCClass;
 import org.robovm.objc.ObjCRuntime;
 import org.robovm.objc.annotation.NativeClass;
@@ -10,6 +12,10 @@ import org.robovm.rt.bro.annotation.Library;
 @Library(Library.INTERNAL)
 @NativeClass()
 public class GPGError extends NSError {
+	public GPGError(String domain, long code, NSDictionary<NSString, ?> dict) {
+		super(domain, code, dict);
+	}
+
 	private static final ObjCClass objCClass = ObjCClass.getByType(GPGError.class);
 
 	static {


### PR DESCRIPTION
This fixes a compilation error in the Google Play Games Services bindings and adds a simple directive to the root build.gradle file. It will ensure that the robovm.xml and all native libraries in a project's libs/ folder are packaged into META-INF/robovm/ios/, as per https://github.com/robovm/robovm/issues/132

Once we publish these to Maven Central and/or SonaType, people can simply take the jar files and add them to their projects, either manually or via a dependency in their Gradle build scripts.
