### PR TITLE
Don't crash if null value passed in parameters map

### DIFF
--- a/flurry/src/org/robovm/bindings/flurry/analytics/Flurry.java
+++ b/flurry/src/org/robovm/bindings/flurry/analytics/Flurry.java
@@ -194,7 +194,8 @@ public class Flurry extends NSObject {
 		if (parameters != null) {
 			NSMutableDictionary<NSString, NSString> nsParams = new NSMutableDictionary<NSString, NSString>();
 			for (java.util.Map.Entry<String, String> entry : parameters.entrySet()) {
-				nsParams.put(new NSString(entry.getKey()), new NSString(entry.getValue()));
+				nsParams.put(new NSString(null != entry.getKey() ? entry.getKey() : ""),
+					     new NSString(null != entry.getValue() ? entry.getValue() : ""));
 			}
 			logEvent(eventName, nsParams, false);
 		} else {


### PR DESCRIPTION
If a null String value is passed into the map, Flurry will crash. Replace null values with an empty string, and replace keys too just in case. (The irony of causing a crash because of passing something to Flurry to report on it should be avoided!)
