### PR TITLE
Fix to make exported symbols work

### DIFF
--- a/chartboost/robovm.xml
+++ b/chartboost/robovm.xml
@@ -26,22 +26,6 @@
 		<framework>StoreKit</framework>
 	</weakFrameworks>
 	<exportedSymbols>
-		<symbol>CBLocationStartup</symbol>
-		<symbol>CBLocationHomeScreen</symbol>
-		<symbol>CBLocationMainMenu</symbol>
-		<symbol>CBLocationGameScreen</symbol>
-		<symbol>CBLocationAchievements</symbol>
-		<symbol>CBLocationQuests</symbol>
-		<symbol>CBLocationPause</symbol>
-		<symbol>CBLocationLevelStart</symbol>
-		<symbol>CBLocationLevelComplete</symbol>
-		<symbol>CBLocationTurnComplete</symbol>
-		<symbol>CBLocationIAPStore</symbol>
-		<symbol>CBLocationItemStore</symbol>
-		<symbol>CBLocationGameOver</symbol>
-		<symbol>CBLocationLeaderBoard</symbol>
-		<symbol>CBLocationSettings</symbol>
-		<symbol>CBLocationQuit</symbol>
-		<symbol>CBLocationDefault</symbol>
+		<symbol>CBLocation*</symbol>
 	</exportedSymbols>
 </config>

--- a/chartboost/src/org/robovm/bindings/chartboost/CBLocation.java
+++ b/chartboost/src/org/robovm/bindings/chartboost/CBLocation.java
@@ -5,6 +5,7 @@ import org.robovm.rt.bro.Bro;
 import org.robovm.rt.bro.LazyGlobalValue;
 import org.robovm.rt.bro.annotation.GlobalValue;
 
+@Library(Library.INTERNAL)
 public class CBLocation {
     static {
         Bro.bind(CBLocation.class);


### PR DESCRIPTION
Couple of fixes after the latest changes on Chartboost bindings.

Added @Library to CBLocation, otherwise an error complaining the annotation is not present is throw.
Small optimization on exported symbols in robovm.xml
