### PR TITLE
Compile error fix, if using robovm 1.0.0. for in-app-purchase

### DIFF
--- a/in-app-purchase/src/org/robovm/bindings/inapppurchase/InAppPurchaseManager.java
+++ b/in-app-purchase/src/org/robovm/bindings/inapppurchase/InAppPurchaseManager.java
@@ -98,7 +98,7 @@ public class InAppPurchaseManager {
         purchasingProduct = true;
 
         System.out.println(TAG + "Purchasing product '" + product.getLocalizedTitle() + "'...");
-        SKPayment payment = SKPayment.createFromProduct(product);
+        SKPayment payment = SKPayment.create(product);
         SKPaymentQueue.getDefaultQueue().addPayment(payment);
     }
 


### PR DESCRIPTION
If using robovm 1.0.0 fixes compile error in InAppPurchaseManager for in-app-purchase subproject.  But this will not be merged soon i guess, because project is still configured with robovm 1.0.0-beta-03. 